### PR TITLE
Try spacejam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 *.sublime-project
 *.sublime-workspace
+upstream
 

--- a/README.md
+++ b/README.md
@@ -4,3 +4,15 @@
 A [Meteor Autopublish](http://meteor.autopublish.com) 
 wrapper for [NVD3](http://nvd3.org).
 
+## Gulp Publish Sequence
+This package is designed to suit the following
+Meteor Autopublish workflow:
+* npm install
+* gulp getUpstream --tag _newtag_
+* gulp test
+* gulp updateVersion --tag _newtag_
+* gulp updateRelease --tag _newtag_
+* git commit -am "Bump to version _newtag_"
+* git push
+* meteor publish
+

--- a/autopublish.json
+++ b/autopublish.json
@@ -2,7 +2,7 @@
   "version": "1.8.1",
   "upstream": {
     "git": "https://github.com/novus/nvd3.git",
-    "release": "1.8.1",
+    "release": "v1.8.1",
     "versionFile": "package.json"
   },
   "hook": {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,6 @@
 // gulpfile.js
-// Taken from https://github.com/MeteorPackaging/numeraljs-core-wrapper/blob/master/gulpfile.js
+// Borrowing heavily from 
+// https://github.com/MeteorPackaging/numeraljs-core-wrapper
 
 var
   autopublish = require('./autopublish.json'),
@@ -36,7 +37,6 @@ gulp.task('getUpstream', function(){
     });
   });
 });
-
 
 // Picks up current version of upstream repo and updates
 // 'package.js' and 'autopublish.json' accordingly
@@ -82,20 +82,7 @@ gulp.task('updateRelease', function() {
         .pipe(gulp.dest('./'));
 });
 
-
-// Donwload scripts necessary to run tests
-// Thanks @aronuda for providing them!
-// https://github.com/arunoda/travis-ci-meteor-packages
-gulp.task('setuptests', function(){
-  return download([
-    'https://raw.github.com/arunoda/travis-ci-meteor-packages/master/start_test.js',
-    'https://raw.github.com/arunoda/travis-ci-meteor-packages/master/phantom_runner.js',
-  ]).pipe(gulp.dest("./"));
-});
-
-
 // Actually run tests
-// NOTE: phantomjs must be available on the system
 gulp.task('test', function(){
   var
     spawn = require('child_process').spawn,
@@ -110,7 +97,6 @@ gulp.task('test', function(){
 
   return tests;
 });
-
 
 // Task that cleans up workspace
 gulp.task('clean', function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,7 +23,7 @@ gulp.task('getUpstream', function(){
     git.clone(autopublish.upstream.git, {args: ' --recursive upstream'}, function (err) {
       if (err) throw err;
       var
-        release = 'v' + autopublish.upstream.release,
+        release = autopublish.upstream.release,
         tag = gutil.env.tag || release,
         path = __dirname + '/upstream/'
       ;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -106,3 +106,4 @@ gulp.task('clean', function() {
     if(err) throw err;
   });
 });
+

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -63,8 +63,8 @@ gulp.task('updateVersion', function() {
     else {
       throw 'Unable to extract current version!';
     }
-    console.log('Verision: ' + version);
-    gulp.src(['package.js', 'autopublish.json'])
+    console.log('Version: ' + version);
+    gulp.src(['package.js', 'autopublish.json', 'package.json'])
       .pipe(replace(versionRegexp, '$1' + version + '$3'))
       .pipe(gulp.dest('./'));
   });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,7 +22,7 @@ gulp.task('getUpstream', function(){
     git.clone(autopublish.upstream.git, {args: ' --recursive upstream'}, function (err) {
       if (err) throw err;
       var
-        release = autopublish.upstream.release,
+        release = 'v' + autopublish.upstream.release,
         tag = gutil.env.tag || release,
         path = __dirname + '/upstream/'
       ;
@@ -99,8 +99,8 @@ gulp.task('setuptests', function(){
 gulp.task('runtests', function(){
   var
     spawn = require('child_process').spawn,
-    tests = spawn('node', ['start_test']);
-    // tests = spawn('spacejam', ['test-packages', './']);
+    // tests = spawn('node', ['start_test']);
+    tests = spawn('node_modules/.bin/spacejam', ['test-packages', './']);
   ;
 
   tests.stdout.pipe(process.stdout);
@@ -115,5 +115,16 @@ gulp.task('runtests', function(){
 
 // Task to be used to test the package
 gulp.task('test', function(){
-  runSequence('setuptests', 'runtests');
+  // runSequence('setuptests', 'runtests');
+  runSequence('runtests');
+});
+
+
+// Task that cleans up workspace
+gulp.task('clean', function() {
+  var cleanable = ['upstream'];
+  console.log("Cleaning " + cleanable.join(','));
+  return del(cleanable, function(err) {
+    if(err) throw err;
+  });
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -96,10 +96,9 @@ gulp.task('setuptests', function(){
 
 // Actually run tests
 // NOTE: phantomjs must be available on the system
-gulp.task('runtests', function(){
+gulp.task('test', function(){
   var
     spawn = require('child_process').spawn,
-    // tests = spawn('node', ['start_test']);
     tests = spawn('node_modules/.bin/spacejam', ['test-packages', './']);
   ;
 
@@ -110,13 +109,6 @@ gulp.task('runtests', function(){
   });
 
   return tests;
-});
-
-
-// Task to be used to test the package
-gulp.task('test', function(){
-  // runSequence('setuptests', 'runtests');
-  runSequence('runtests');
 });
 
 

--- a/meteor-post.js
+++ b/meteor-post.js
@@ -1,0 +1,2 @@
+nv = window.nv;
+delete window.nv;

--- a/package.js
+++ b/package.js
@@ -4,18 +4,18 @@
 Package.describe({
   name: 'jdlubrano:nvd3-wrapper', // this name will be changed once the autopublish workflow is confirmed to be working
   summary: 'NVD3 (not yet official) - Reusable charts for d3.js',
-  version: '0.0.1',
+  version: '1.8.1',
   git: 'https://github.com/MeteorPackaging/nvd3-wrapper.git'
 });
 
 Package.onUse(function(api) {
   api.versionsFrom('1.0.1');
+  api.use('d3js:d3@3.5.5', 'client');
   api.addFiles([
-    'meteor-pre.js',
     'upstream/build/nv.d3.js',
     'upstream/build/nv.d3.css',
     'meteor-post.js'
-  ]);
+  ], 'client');
   api.export('nv');
 });
 
@@ -29,6 +29,6 @@ Package.onTest(function(api) {
 
   api.addFiles([
     'tests/nv-is-defined-test.js'
-  ]);
+  ], 'client');
 });
 

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@
 // The Meteor package file.
 
 Package.describe({
-  name: 'jdlubrano:nvd3-wrapper', // this name will be changed once the autopublish workflow is confirmed to be working
+  name: 'nvd3:nvd3-wrapper', // this name will be changed once the autopublish workflow is confirmed to be working
   summary: 'NVD3 (not yet official) - Reusable charts for d3.js',
   version: '1.8.1',
   git: 'https://github.com/MeteorPackaging/nvd3-wrapper.git'
@@ -20,7 +20,7 @@ Package.onUse(function(api) {
 });
 
 Package.onTest(function(api) {
-  api.use('jdlubrano:nvd3-wrapper');
+  api.use('nvd3:nvd3-wrapper');
 
   api.use([
     'tinytest',

--- a/package.json
+++ b/package.json
@@ -1,4 +1,8 @@
 {
+  "name": "nvd3-wrapper",
+  "version": "1.8.1",
+  "license": "Apache-2.0",
+  "repository": "https://github.com/MeteorPackaging/nvd3-wrapper.git",
   "devDependencies": {
     "del": "^1.1.1",
     "gulp": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "devDependencies": {
-    "del": "^2.0.2",
+    "del": "^1.1.1",
     "gulp": "^3.9.0",
     "gulp-download": "0.0.1",
     "gulp-git": "^1.5.0",
     "gulp-replace": "^0.5.4",
     "gulp-util": "^3.0.6",
-    "run-sequence": "^1.1.4"
+    "run-sequence": "^1.1.4",
+    "spacejam": "^1.2.2"
   }
 }

--- a/tests/nv-is-defined-test.js
+++ b/tests/nv-is-defined-test.js
@@ -1,0 +1,5 @@
+// nv-is-defined-test.js
+
+Tinytest.add('nv object is defined', function(test) {
+  test.isNotUndefined(nv, 'nv is undefined at global scope for Meteor');
+});


### PR DESCRIPTION
Integrate changes resulting in a fully functional gulp/autopublish workflow (see README for steps).  For now the package will be named `nvd3:nvd3-wrapper`.  Folks may already be using the `nvd3:nvd3` wrapper and breaking it would be undesirable.  We should be able to test that the autopublish workflow is successful with this `nvd3:nvd3-wrapper` package before simply changing the name over to `nvd3:nvd3`.
